### PR TITLE
Time flow direction feature on chord(s)

### DIFF
--- a/sora/lightcurve/utils.py
+++ b/sora/lightcurve/utils.py
@@ -200,14 +200,20 @@ def read_lc_file(lc_file, usecols=None, skiprows=0):
                 time_col_index, flux_col_index = usecols
                 time_col_name = lc_data.colnames[time_col_index]
                 flux_col_name = lc_data.colnames[flux_col_index]
-                time, flux = Time(lc_data[time_col_name].data).jd, lc_data[flux_col_name].data
+                if ":" in str(lc_data[time_col_name].data[0]):
+                    time, flux = Time(lc_data[time_col_name].data).jd, lc_data[flux_col_name].data
+                else:
+                    time, flux = Time(lc_data[time_col_name].data, format="jd").jd, lc_data[flux_col_name].data
                 return time, flux
             elif len(usecols) == 3:
                 time_col_index, flux_col_index, dflux_col_index = usecols
                 time_col_name = lc_data.colnames[time_col_index]
                 flux_col_name = lc_data.colnames[flux_col_index]
                 dflux_col_name = lc_data.colnames[dflux_col_index]
-                time, flux = Time(lc_data[time_col_name].data).jd, lc_data[flux_col_name].data
+                if ":" in str(lc_data[time_col_name].data[0]):
+                    time, flux = Time(lc_data[time_col_name].data).jd, lc_data[flux_col_name].data
+                else:
+                    time, flux = Time(lc_data[time_col_name].data, format="jd").jd, lc_data[flux_col_name].data
                 dflux = lc_data[dflux_col_name].data
                 return time, flux, dflux
             else:

--- a/sora/occultation/chord.py
+++ b/sora/occultation/chord.py
@@ -4,6 +4,7 @@ import astropy.units as u
 import numpy as np
 from astropy.coordinates import SkyOffsetFrame
 from astropy.time import Time
+from .utils import add_arrow
 
 __all__ = ['Chord']
 
@@ -310,7 +311,8 @@ class Chord:
 
         return vals
 
-    def plot_chord(self, *, segment='standard', only_able=False, ax=None, linestyle='-', **kwargs):
+    def plot_chord(self, *, segment='standard', only_able=False, ax=None, linestyle='-',
+                       time_direction=False, **kwargs):
         """Plots the on-sky path of this chord.
 
         This Chord object must be associated to an Occultation to work, since
@@ -353,6 +355,9 @@ class Chord:
             The difference is that now it accepts ``linestyle='exposure'``, where
             the plot will be a dashed line corresponding to each exposure.
             The blank space between the lines can be interpreted as 'dead time'.
+
+        time_direction : `bool`
+            If enabled, it draws the direction of time flow on the chord line.
 
         **kwargs
             Any other kwarg will be parsed directly by `maplotlip.pyplot.plot`.
@@ -398,6 +403,16 @@ class Chord:
             var += ax.plot(*vals, **kwargs)
         if len(var) > 0:
             var[0].set_label(label)
+            if time_direction is True:
+                if segment != 'error':
+                    in_fg = self.get_fg(time=[self.lightcurve.initial_time])[0]
+                    out_fg = self.get_fg(time=[self.lightcurve.end_time])[0]
+                    if out_fg[0] > in_fg[0]:
+                        add_arrow(var[0], direction='right')
+                    elif out_fg[0] < in_fg[0]:
+                        add_arrow(var[0], direction='left')
+                    else:
+                        pass
 
     def get_impact_param(self, center_f=0, center_g=0, verbose=True):
         """Gets the impact parameter, minimal distance between the chord and the

--- a/sora/occultation/utils.py
+++ b/sora/occultation/utils.py
@@ -1,7 +1,7 @@
 import astropy.units as u
 import numpy as np
 
-__all__ = ['filter_negative_chord', 'positionv']
+__all__ = ['filter_negative_chord', 'positionv', 'add_arrow']
 
 
 def positionv(star, ephem, observer, time):
@@ -175,3 +175,51 @@ def calc_geometric_albedo(equivalent_radius, H_obj, equivalent_radius_error=0, H
         else:
             print('geometric albedo: {:.3f} \n'.format(geometric_albedo))
     return geometric_albedo, delta_albedo
+
+
+def add_arrow(line, position=None, direction='right', size=15, color=None):
+    """ Add an arrow to a chord.
+
+        Parameters
+        ----------
+        line : `Line2D object`
+            Line2D object
+
+        position : `float`, `int`
+            x-position of the arrow. If None, mean of xdata is taken.
+
+        direction : `string`, default='right'
+            'left' or 'right'
+
+        size : `float`, `int`, default=15
+            Size of the arrow in fontsize points.
+
+        color : `string`, default=None
+            If None, line color is taken.
+
+        See Also
+        --------
+        https://stackoverflow.com/a/34018322/3137585
+    """
+
+    if color is None:
+        color = line.get_color()
+
+    xdata = line.get_xdata()
+    ydata = line.get_ydata()
+
+    if position is None:
+        position = xdata.mean()
+    # find closest index
+    start_ind = np.argmin(np.absolute(xdata - position))
+    if direction == 'right':
+        end_ind = start_ind + 1
+    else:
+        end_ind = start_ind - 1
+
+    line.axes.annotate('',
+                       xytext=(xdata[start_ind], ydata[start_ind]),
+                       xy=(xdata[end_ind], ydata[end_ind]),
+                       arrowprops=dict(arrowstyle="->", color=color),
+                       size=size
+                       )


### PR DESCRIPTION
I fixed a small bug in the section I contributed previously. I was getting an error if the time column was JD, but I fixed it (within the read_lc_file function).

```python
lc = LightCurve(name='Test',
                file='test_occultationportal_lc.csv', 
                exptime=10.000,
                usecols=[0, 5, 6], skiprows=1)
```

[Test file link](https://www.dropbox.com/s/dsgdb3p8kmckwxx/test_occultationportal_lc.csv?dl=0).

Another contribution was that sometimes the immersion and emersion part of the _chords.plot_chords_ function could be confused. I wanted to show the direction of time flow. It is very simple to use;

`python
occ.chords.plot_chords(time_direction=True)
`

[Example view.](https://www.dropbox.com/s/w1xqommxmmq5a43/test_time_direction.png?dl=0)

No arguments need to be given if not required plotting direction of time flow.

`python
occ.chords.plot_chords()
`

I hope it will be useful. 