### PR TITLE
Implement Gaia-DR3

### DIFF
--- a/docs/releases/v0.3.rst
+++ b/docs/releases/v0.3.rst
@@ -7,6 +7,8 @@ New Features
 sora.body
 ^^^^^^^^^
 
+- Added `get_position()` in Body as a shortcut to `ephem.get_position()`. [:issue:`76`]
+
 sora.config
 ^^^^^^^^^^^
 
@@ -30,6 +32,8 @@ sora.prediction
 
 - Included the ``VizierCatalogue`` in the prediction function. [:issue:`71`]
 
+- Defined Gaia-DR3 as the default in the `prediction()` function. [:issue:`76`]
+
 sora.star
 ^^^^^^^^^
 
@@ -37,6 +41,10 @@ sora.star
   and usage of any catalogue available on Vizier. [:issue:`71`]
 
 - Included the ``VizierCatalogue`` in the Star class. [:issue:`71`]
+
+- Included the Gaia-DR3 catalogue, released on June 13, 2022, in the catalogue list. [:issue:`76`]
+
+- Defined Gaia-DR3 as the default in the Star class. [:issue:`76`]
 
 API Changes
 -----------
@@ -49,6 +57,9 @@ sora.config
 
 sora.ephem
 ^^^^^^^^^^
+
+- `id_type` for planets and satellites are passed as `None` instead of `major_body`,
+  following changes made in Horizons. [:issue:`76`]
 
 sora.extra
 ^^^^^^^^^^

--- a/sora/body/core.py
+++ b/sora/body/core.py
@@ -234,6 +234,26 @@ class Body(BaseBody):
                               "Tholen": {"value": None, "reference": None, "notes": None}}
         self.discovery = ""
 
+    def get_position(self, time, observer='geocenter'):
+        """Returns the object geocentric position.
+
+        Parameters
+        ----------
+        time : `str`, `astropy.time.Time`
+            Reference time to calculate the object position. It can be a string
+            in the ISO format (yyyy-mm-dd hh:mm:ss.s) or an astropy Time object.
+
+        observer : `str`, `sora.Observer`, `sora.Spacecraft`
+            IAU code of the observer (must be present in given list of kernels),
+            a SORA observer object or a string: ['geocenter', 'barycenter']
+
+        Returns
+        -------
+        coord : `astropy.coordinates.SkyCoord`
+            Astropy SkyCoord object with the object coordinates at the given time.
+        """
+        return self.ephem.get_position(time=time, observer=observer)
+
     def get_pole_position_angle(self, time, observer='geocenter'):
         """Returns the pole position angle and the aperture angle relative to
         the geocenter.

--- a/sora/ephem/utils.py
+++ b/sora/ephem/utils.py
@@ -282,6 +282,7 @@ def ephem_horizons(time, target, observer, id_type='smallbody', output='ephemeri
     if getattr(observer, 'ephem', None) not in ['horizons', None]:
         warnings.warn('Ephemeris using kernel for the observer and Horizons for the target is under construction. '
                       'We will use only Horizons.')
+    id_type = None if id_type == 'majorbody' else id_type
     ob = Horizons(id=target, id_type=id_type, location=location, epochs=time2)
 
     if output == 'ephemeris':

--- a/sora/prediction/core.py
+++ b/sora/prediction/core.py
@@ -115,7 +115,7 @@ def occ_params(star, ephem, time, n_recursions=5, max_tdiff=None, reference_cent
 
 
 @deprecated_alias(log='verbose')  # remove this line in v1.0
-def prediction(time_beg, time_end, body=None, ephem=None, mag_lim=None, catalogue='gaiaedr3', step=60, divs=1, sigma=1,
+def prediction(time_beg, time_end, body=None, ephem=None, mag_lim=None, catalogue='gaiadr3', step=60, divs=1, sigma=1,
                radius=None, verbose=True, reference_center='geocenter'):
     """Predicts stellar occultations.
 
@@ -141,7 +141,7 @@ def prediction(time_beg, time_end, body=None, ephem=None, mag_lim=None, catalogu
 
     catalogue : `str`, `VizierCatalogue`
         The catalogue to download data. It can be ``'gaiadr2'``, ``'gaiaedr3'``,
-        or a VizierCatalogue object. default='gaiaedr3'
+        ``'gaiadr3'``, or a VizierCatalogue object. default='gaiadr3'
 
     step : `int`, `float`, default=60
         Step, in seconds, of ephem times for search

--- a/sora/star/catalog.py
+++ b/sora/star/catalog.py
@@ -238,5 +238,11 @@ gaiaedr3 = VizierCatalogue(name='GaiaEDR3', cat_path='I/350/gaiaedr3', code='Sou
                            pmra='pmRA', pmdec='pmDE', epoch='Epoch', parallax='Plx', rad_vel='RVDR2', band={'G': 'Gmag'},
                            errors=['e_RA_ICRS', 'e_DE_ICRS', 'e_pmRA', 'e_pmDE', 'e_Plx', 'e_RVDR2'])
 
+epoch = Time('J2016.0', scale='tdb')
+gaiadr3 = VizierCatalogue(name='GaiaDR3', cat_path='I/355/gaiadr3', code='Source', ra='RA_ICRS', dec='DE_ICRS',
+                          pmra='pmRA', pmdec='pmDE', epoch=epoch, parallax='Plx', rad_vel='RV', band={'G': 'Gmag'},
+                          errors=['e_RA_ICRS', 'e_DE_ICRS', 'e_pmRA', 'e_pmDE', 'e_Plx', 'e_RV'])
 
-allowed_catalogues = SelectDefault(instance=VizierCatalogue, defaults={'gaiadr2': gaiadr2, 'gaiaedr3': gaiaedr3})
+
+allowed_catalogues = SelectDefault(instance=VizierCatalogue,
+                                   defaults={'gaiadr2': gaiadr2, 'gaiaedr3': gaiaedr3, 'gaiadr3': gaiadr3})

--- a/sora/star/core.py
+++ b/sora/star/core.py
@@ -23,7 +23,7 @@ class Star(MetaStar):
     ----------
     catalogue : `str`, `VizierCatalogue`
         The catalogue to download data. It can be ``'gaiadr2'``, ``'gaiaedr3'``,
-        or a VizierCatalogue object.. default='gaiaedr3'
+        ``'gaiadr3'``, or a VizierCatalogue object.. default='gaiadr3'
 
     code : `str`
         Gaia Source code for searching in VizieR.
@@ -81,7 +81,7 @@ class Star(MetaStar):
     """
 
     @deprecated_alias(log='verbose')  # remove this line in v1.0
-    def __init__(self, catalogue='gaiaedr3', **kwargs):
+    def __init__(self, catalogue='gaiadr3', **kwargs):
 
         self._attributes = {}
         self.mag = {}
@@ -286,7 +286,7 @@ class Star(MetaStar):
         Parameters
         ----------
         catalog : `VizierCatalogue`
-            The catalogue to download data. It can be ``'gaiadr2'`` or ``'gaiaedr3'``.
+            The catalogue to download data. It can be ``'gaiadr2'``, ``'gaiaedr3'`` or ``'gaiadr3'``.
         """
         if hasattr(self, 'code'):
             catalogue = catalog.search_star(code=self.code)
@@ -307,7 +307,7 @@ class Star(MetaStar):
         self.code = str(cat_data['code'][0])
         self.epoch = cat_data['epoch'][0]
         self.set_magnitude(**{band: value[0].value for band, value in cat_data['band'].items()})
-        if self.__cgaudin and catalog.name == 'GaiaEDR3':
+        if self.__cgaudin and catalog.name in ['GaiaEDR3', 'GaiaDR3']:
             from sora.star.utils import edr3ToICRF
             self.pmra, self.pmdec = edr3ToICRF(pmra = self.pmra, pmdec = self.pmdec,
                                                ra = self.ra.deg, dec = self.dec.deg, 
@@ -336,7 +336,7 @@ class Star(MetaStar):
         x = cov[2, 2] * (self.rad_vel.value ** 2 + self.errors['rad_vel'].value ** 2) / (
             A ** 2) + (self.parallax.to(u.rad).value * self.errors['rad_vel'].value / A) ** 2
         cov[5, 5] = x
-        if catalog.name in ['GaiaDR2', 'GaiaEDR3']:
+        if catalog.name in ['GaiaDR2', 'GaiaEDR3', 'GaiaDR3']:
             a = ['RA', 'DE', 'Plx', 'pmRA', 'pmDE']
             for i in np.arange(5):
                 v1 = 'e_' + a[i]
@@ -541,7 +541,7 @@ class Star(MetaStar):
             out += 'User coordinates\n'
         text_cgaudin = ''
         if self.__cgaudin:
-            text_cgaudin = 'Gaia-EDR3 Proper motion corrected as suggested by Cantat-Gaudin & Brandt (2021) \n'
+            text_cgaudin = f'{self._catalogue} Proper motion corrected as suggested by Cantat-Gaudin & Brandt (2021) \n'
         out += ('ICRS star coordinate at J{}:\n'
                 'RA={} +/- {:.4f}, DEC={} +/- {:.4f}\n'
                 'pmRA={:.3f} +/- {:.3f} mas/yr, pmDEC={:.3f} +/- {:.3f} mas/yr\n{}'

--- a/sora/star/meta.py
+++ b/sora/star/meta.py
@@ -185,7 +185,7 @@ class MetaStar:
     @property
     def diameter_gaia(self):
         try:
-            rad = self.meta_gaia.get('Rad')
+            rad = self.meta_catalogue.get('Rad')
             if rad is not None and not np.ma.core.is_masked(rad):
                 return 2*np.arctan((rad*u.solRad)/self.distance).to(u.mas)
         except:


### PR DESCRIPTION
This Pull Request Implements Gaia-DR3 into SORA. The upgrade is basically the new radial velocity in DR3, while EDR3 used DR2 radial velocities. RUWE and Dup are also interpreted. Proper motions are corrected by Cantat-Gaudin (2021).

This PR also fixes issue #70, where a warning is raised due to modifications in astroquery.

Finally, I added a shortcut to allow the user to get the ephemeris directly from the body object. This puts the `get_position` command at the same level as Star's. Thus, events involving star-star, body-star, and body-body can be easily implemented in the future.