### PR TITLE
fix issue #93

### DIFF
--- a/sora/body/shape/core.py
+++ b/sora/body/shape/core.py
@@ -163,7 +163,10 @@ class Shape3D(BaseShape):
         x = - faced_vertices.T[observable].y.value + center_f
         y = faced_vertices.T[observable].z.value + center_g
         triangles = [geometry.Polygon(np.transpose(triangle)) for triangle in zip(x, y)]
-        pol = unary_union(triangles)
+        
+        valid_triangles = [poly.buffer(0) if not poly.is_valid else poly for poly in triangles]
+        
+        pol = unary_union(valid_triangles)
         limb = pol.boundary
         if isinstance(limb, geometry.multilinestring.MultiLineString):
             limb = limb.geoms[0]


### PR DESCRIPTION
This error indicates an issue with the geometries being merged using Shapely's unary_union. It often happens when geometries have overlapping or intersecting regions that create a "side location conflict," preventing a successful union.