### PR TITLE
New corrections for v0.3

### DIFF
--- a/sora/body/core.py
+++ b/sora/body/core.py
@@ -510,7 +510,7 @@ class Body(BaseBody):
             if value:
                 out.append('    Tholen: {} [Reference: {}]\n'.format(value, self.spectral_type['Tholen']['reference']))
             out += " "*7 + (smass.get(self.spectral_type['SMASS']['value']) or
-                            tholen.get(self.spectral_type['Tholen']['value'])) + "\n"
+                            tholen.get(self.spectral_type['Tholen']['value']) or '') + "\n"
         out.append(self.discovery)
 
         out.append('\n\nPhysical parameters:\n')

--- a/sora/body/meta.py
+++ b/sora/body/meta.py
@@ -106,6 +106,8 @@ class PhysicalData(u.Quantity):
             raise ValueError('Given value must be a scalar. Given: {}'.format(value))
         if not unit.is_equivalent(self.unit):
             raise ValueError('{} is not equivalent to {}'.format(unit, given_unit))
+        if '/' in str(value):
+            value = np.max(np.absolute([float(i) for i in str(value).split('/')]))
         self._uncertainty = u.Quantity(value, unit).to(given_unit)
         if self._uncertainty < 0:
             raise ValueError('uncertainty cannot be a negative value')

--- a/sora/observer/core.py
+++ b/sora/observer/core.py
@@ -1,6 +1,9 @@
+import warnings
+
 import astropy.units as u
 from astropy.coordinates import SkyCoord, EarthLocation, GCRS, AltAz
 from astropy.time import Time
+from astropy.utils.exceptions import AstropyWarning
 
 from sora.config import input_tests
 from .utils import search_code_mpc
@@ -203,7 +206,9 @@ class Observer:
         from sora.ephem.utils import ephem_horizons, ephem_kernel
 
         itrs = self.site.get_itrs(obstime=time)
-        gcrs = itrs.transform_to(GCRS(obstime=time))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', AstropyWarning)
+            gcrs = itrs.transform_to(GCRS(obstime=time))
 
         if self.ephem == 'horizons':
             vector = ephem_horizons(time=time, target=self.spkid, observer=origin, id_type='majorbody', output='vector')

--- a/sora/occultation/fitting.py
+++ b/sora/occultation/fitting.py
@@ -527,7 +527,8 @@ def __fit_ellipse_parallel(values, bestchi, equatorial_radius, dequatorial_radiu
     return [chi2_best, f0_chi, g0_chi, a_chi,  obla_chi, posang_chi]
 
 
-def fit_to_limb(limb, fg, error, center_f=0, dcenter_f=0, center_g=0, dcenter_g=0, scale=1, dscale=0, loop=150000):
+def fit_to_limb(limb, fg, error, center_f=0, dcenter_f=0, center_g=0, dcenter_g=0, scale=1, dscale=0, loop=150000,
+                model_error=0):
     """
 
     Parameters
@@ -565,6 +566,9 @@ def fit_to_limb(limb, fg, error, center_f=0, dcenter_f=0, center_g=0, dcenter_g=
     loop : `int`, default=150000
         The number of centers to attempt fitting.
 
+     model_error :  `int`, `float`, default=0
+        Model uncertainty to be considered in the fit, in km.
+
     Returns
     -------
 
@@ -590,7 +594,7 @@ def fit_to_limb(limb, fg, error, center_f=0, dcenter_f=0, center_g=0, dcenter_g=
     x0 = center_f + dcenter_f * (2 * np.random.random(loop) - 1)
     y0 = center_g + dcenter_g * (2 * np.random.random(loop) - 1)
     s0 = scale + dscale * (2 * np.random.random(loop) - 1)
-    err2 = np.square(error)
+    err2 = np.square(error) + np.square(model_error)
 
     def calc_dist(item):
         residual = limb_radial_residual(limb, fg, center_f=x0[item], center_g=y0[item], scale=s0[item])
@@ -601,7 +605,8 @@ def fit_to_limb(limb, fg, error, center_f=0, dcenter_f=0, center_g=0, dcenter_g=
     return ChiSquare(chi2, center_f=x0, center_g=y0, scale=s0, npts=len(fg))
 
 
-def fit_shape(occ, center_f=0, dcenter_f=0, center_g=0, dcenter_g=0, scale=1, dscale=0, loop=150000, sigma_result=1):
+def fit_shape(occ, center_f=0, dcenter_f=0, center_g=0, dcenter_g=0, scale=1, dscale=0, loop=150000, sigma_result=1,
+              model_error=0):
     """
     Parameters
     ----------
@@ -623,6 +628,8 @@ def fit_shape(occ, center_f=0, dcenter_f=0, center_g=0, dcenter_g=0, scale=1, ds
         The number of centers to attempt fitting.
     sigma_result : `int`, `float`
         Sigma value to be considered as result.
+    model_error :  `int`, `float`, default=0
+        Model uncertainty to be considered in the fit, in km.
 
     Returns
     -------
@@ -635,7 +642,7 @@ def fit_shape(occ, center_f=0, dcenter_f=0, center_g=0, dcenter_g=0, scale=1, ds
     limb = occ.body.shape.get_limb(**orientation)
     chord_names, fg, error = occ.chords.get_limb_points()
     chisquare = fit_to_limb(limb, fg, error, center_f=center_f, dcenter_f=dcenter_f, center_g=center_g, dcenter_g=dcenter_g,
-                            scale=scale, dscale=dscale, loop=loop)
+                            scale=scale, dscale=dscale, loop=loop, model_error=model_error)
 
     result_sigma = chisquare.get_nsigma(sigma=sigma_result)
     occ.fitted_params = {i: result_sigma[i] for i in ['center_f', 'center_g', 'scale']}

--- a/sora/occultation/utils.py
+++ b/sora/occultation/utils.py
@@ -1,7 +1,6 @@
 import numpy as np
 import astropy.constants as const
 import astropy.units as u
-from astropy.coordinates import SkyOffsetFrame
 
 from sora.body import Body
 from sora.ephem import EphemHorizons
@@ -230,10 +229,6 @@ def add_arrow(line, position=None, direction='right', size=15, color=None):
                        )
 
 
-sun = Body(name='Sun', spkid='10', ephem=EphemHorizons(name='Sun', spkid=10, id_type='majorbody'),
-           GM=const.G*(1*u.M_sun), database=None)
-
-
 def calc_sun_dif_ld(body_coord, star_coord, time, observer="geocenter"):
     """Computes differential light deflection of star and body caused by the Sun.
 
@@ -262,6 +257,8 @@ def calc_sun_dif_ld(body_coord, star_coord, time, observer="geocenter"):
     import erfa
     from astropy.coordinates import SkyCoord
 
+    sun = Body(name='Sun', spkid='10', ephem=EphemHorizons(name='Sun', spkid=10, id_type='majorbody'),
+               GM=const.G * (1 * u.M_sun), database=None)
     pos_sun = sun.get_position(time=time, observer=observer)
     bm = 1  # Sun Mass in Solar Masses
 

--- a/sora/prediction/occmap.py
+++ b/sora/prediction/occmap.py
@@ -1,5 +1,6 @@
 import os
 import warnings
+from pathlib import Path
 
 import astropy.constants as const
 import astropy.units as u
@@ -397,8 +398,7 @@ def plot_occ_map(name, radius, coord, time, ca, pa, vel, dist, mag=0, longi=0, *
     arrow = kwargs.get('arrow', True)
     site_name = kwargs.get('site_name', True)
     path = kwargs.get('path', '.')
-    if not os.path.exists(path):
-        raise IOError('Path does not exists')
+    Path(path).mkdir(parents=True, exist_ok=True)
     chord_delta = np.array(kwargs.get('chord_delta', []), ndmin=1)*u.km
     chord_geo = kwargs.get('chord_geo', [])
     if len(chord_geo) > 0:

--- a/sora/prediction/occmap.py
+++ b/sora/prediction/occmap.py
@@ -1,10 +1,12 @@
 import os
+import warnings
 
 import astropy.constants as const
 import astropy.units as u
 import numpy as np
 from astropy.coordinates import GCRS, ITRS, SkyOffsetFrame, SkyCoord, EarthLocation, Angle, get_sun
 from astropy.time import Time
+from astropy.utils.exceptions import AstropyWarning
 
 from sora.config import input_tests
 
@@ -38,8 +40,10 @@ def xy2latlon(x, y, loncen, latcen, time):
     """
     r = const.R_earth.to(u.m).value
     site_cen = EarthLocation(loncen*u.deg, latcen*u.deg)
-    itrs_cen = site_cen.get_itrs(obstime=time)
-    gcrs_cen = itrs_cen.transform_to(GCRS(obstime=time))
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', AstropyWarning)
+        itrs_cen = site_cen.get_itrs(obstime=time)
+        gcrs_cen = itrs_cen.transform_to(GCRS(obstime=time))
 
     z = np.array(y, ndmin=1)
     y = np.array(x, ndmin=1)
@@ -64,8 +68,10 @@ def xy2latlon(x, y, loncen, latcen, time):
             n_itrs = n_coord.transform_to(ITRS(obstime=time))
             n_site = n_itrs.earth_location
             n_site = EarthLocation(n_site.lon, n_site.lat, 0)
-            itrs_site = n_site.get_itrs(obstime=time)
-            gcrs_site = itrs_site.transform_to(GCRS(obstime=time))
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', AstropyWarning)
+                itrs_site = n_site.get_itrs(obstime=time)
+                gcrs_site = itrs_site.transform_to(GCRS(obstime=time))
             target1 = gcrs_site.transform_to(center_frame[a])
             if n == 4:
                 lon[a] = n_site.lon.deg

--- a/sora/prediction/table.py
+++ b/sora/prediction/table.py
@@ -7,6 +7,7 @@ import numpy as np
 from astropy.coordinates import SkyCoord, get_body
 from astropy.table import Table, Row, Column
 from astropy.time import Time
+from astropy.utils.exceptions import AstropyWarning
 
 from sora.config import input_tests
 
@@ -240,9 +241,9 @@ class PredictionTable(Table):
                 ntime = time + longi.hour*u.hour
                 values['loct'] = Column(['{}'.format(t.iso[11:16]) for t in ntime], unit='hh:mm')
             moon_pos = get_body('moon', time)
-            values['M-G-T'] = Column(moon_pos.separation(coord), unit='deg', format='3.0f')
+            values['M-G-T'] = Column(moon_pos.separation(coord, origin_mismatch="ignore"), unit='deg', format='3.0f')
             sun_pos = get_body('sun', time)
-            values['S-G-T'] = Column(sun_pos.separation(coord), unit='deg', format='3.0f')
+            values['S-G-T'] = Column(sun_pos.separation(coord, origin_mismatch="ignore"), unit='deg', format='3.0f')
             catalogue = kwargs.get('meta', {}).get('catalogue', '')
             if 'source' in kwargs.keys():
                 values[f'{catalogue} Source ID'] = Column(kwargs['source'], dtype='str')
@@ -442,11 +443,14 @@ class PredictionTable(Table):
         f.close()
 
     def plot_occ_map(self, **kwargs):
-        basename = kwargs.get('nameimg', None)
-        for i in range(len(self)):
-            if basename and len(self) > 1:
-                kwargs['nameimg'] = f'{basename}_{i}'
-            self[i].plot_occ_map(**kwargs)
+        from astropy.utils.exceptions import AstropyWarning
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', AstropyWarning)
+            basename = kwargs.get('nameimg', None)
+            for i in range(len(self)):
+                if basename and len(self) > 1:
+                    kwargs['nameimg'] = f'{basename}_{i}'
+                self[i].plot_occ_map(**kwargs)
 
     plot_occ_map.__doc__ = PredictRow.plot_occ_map.__doc__
 

--- a/sora/star/core.py
+++ b/sora/star/core.py
@@ -97,6 +97,8 @@ class Star(MetaStar):
         self.bjones = False
         self.__cgaudin = kwargs.get('cgaudin', True)
 
+        self.code = ''
+        self.cov = np.zeros((6, 6))
         if 'code' in kwargs:
             self.code = kwargs['code']
         if 'coord' in kwargs:

--- a/sora/star/core.py
+++ b/sora/star/core.py
@@ -291,13 +291,13 @@ class Star(MetaStar):
         if hasattr(self, 'code'):
             catalogue = catalog.search_star(code=self.code)
         else:
-            catalogue = catalog.search_star(coord=self.coord, radius=2 * u.arcsec)
+            catalogue = catalog.search_star(coord=self.coord, radius=1 * u.arcsec)
         if len(catalogue) == 0:
             raise ValueError('No star was found. It does not exist or VizieR is out.')
         catalogue = catalogue[0]
         if len(catalogue) > 1:
             if self._verbose:
-                print('{} stars were found within 2 arcsec from given coordinate.'.format(len(catalogue)))
+                print('{} stars were found within 1 arcsec from given coordinate.'.format(len(catalogue)))
                 print('The list below is sorted by distance. Please select the correct star')
             catalogue = choice_star(catalogue, self.coord, ['RA_ICRS', 'DE_ICRS', 'Gmag'], source='gaia')
         cat_data = catalog.parse_catalogue(catalogue)


### PR DESCRIPTION
Make new corrections:

- Include `model_error`in 3D limb fitting
- Make the area of search for individual stars as one arcsec in Star when using coordinates.
- Remove a large number of repeated warning messages in predictions and map plotting related to polar motion.
- Included default parameters that prevented the Star module from being used from local information.
- Fixed error when reading the error bar from SBDB if it has two values separated by a '/'.
- Now when saving a map to a folder, if the folder does not exist, it is created.
- Move the definition of the Sun used in light deflection to prevent error when offline
- Fixed bug that happens when Body does not have pre-defined spectral-type