### PR TITLE
resolve #101

### DIFF
--- a/sora/ephem/utils.py
+++ b/sora/ephem/utils.py
@@ -259,11 +259,13 @@ def ephem_horizons(time, target, observer, id_type='smallbody', output='ephemeri
     location = origins.get(observer)
     if not location and isinstance(observer, str):
         location = observer
-    if isinstance(observer, (Observer, Spacecraft)):
+    if isinstance(observer, Observer):
         if getattr(observer, "code", None) is None:
             location = {'lon': observer.lon.deg, 'lat': observer.lat.deg, 'elevation': observer.height.to(u.km).value}
         else:
             location = f'{getattr(observer, "code", "")}@{getattr(observer, "spkid", "")}'
+    elif isinstance(observer, Spacecraft):
+        location = f"500@{getattr(observer, 'spkid', '')}"
     if not location:
         raise ValueError("observer must be 'geocenter', 'barycenter' or an observer object.")
     if output not in ['ephemeris', 'vector']:


### PR DESCRIPTION
This PR should fix #101 by separating the observer type check in `sora.ephem.utils.ephem_horizons` into two separate blocks, one for `Observer` and one for `Spacecraft`. With this change, the example given in #101 now evaluates fine:

```python
from astropy.time import Time
from sora import Body, Spacecraft, Star
from sora.prediction import occ_params

chariklo = Body(name="Chariklo", ephem="horizons")
nh = Spacecraft(name="New Horizons", spkid="-98", ephem="horizons")
star = Star(code="3089856131952198272", verbose=True)

tca, ca, pa, vel, dist = occ_params(
    star=star,
    ephem=chariklo.ephem,
    time=Time("2013-07-13 13:37:48.260"),
    n_recursions=5,
    max_tdiff=None,
    reference_center=nh,
)

print('Time of the CA:   {} UTC'.format(tca))
print('Closest Approach: {:.3f}'.format(ca))
print('Position Angle:   {:.3f}'.format(pa))
print('Shadow Velocity:  {:.3f}'.format(vel))
print('Object Distance:  {:.5f}'.format(dist))
```

```
SORA version: 0.3.2
Obtaining data for Chariklo from SBDB
1 GaiaDR3 star found band={'G': 17.949968}
star coordinate at J2016.0: RA=8h10m44.43109s +/- 0.1055 mas, DEC=1d27m22.8644s +/- 0.0783 mas

Downloading star parameters from I/297/out
Time of the CA:   2013-07-13 13:37:40.840 UTC
Closest Approach: 0.037 arcsec
Position Angle:   40.526 deg
Shadow Velocity:  -7.990 km [/](https://file+.vscode-resource.vscode-cdn.net/) s
Object Distance:  15.97781 AU
```

Let me know how this looks, or if there are any changes you'd like to see!