### PR TITLE
Include functions to compute Equivalent Radius

### DIFF
--- a/sora/body/shape/core.py
+++ b/sora/body/shape/core.py
@@ -95,6 +95,18 @@ class Shape3D(BaseShape):
         self._scale = float(value)
         self.get_limb.cache_clear()
 
+    @property
+    def volume(self):
+        v = self.vertices[self.faces.T]
+        ab = v[1] - v[0]
+        ac = v[2] - v[0]
+        normal = ab.cross(ac)
+        return normal.dot(v[0]).sum() / 6
+
+    @property
+    def volumetric_equivalent_radius(self):
+        return (3 * self.volume / (4 * np.pi)) ** (1. / 3.)
+
     def rotated_vertices(self, sub_observer="00 00 00 +00 00 00", pole_position_angle=0):
         """Returns the vertices rotated as viewed by a given observer,
         with 'x' in the direction of the observer.

--- a/sora/body/shape/core.py
+++ b/sora/body/shape/core.py
@@ -107,6 +107,18 @@ class Shape3D(BaseShape):
     def volumetric_equivalent_radius(self):
         return (3 * self.volume / (4 * np.pi)) ** (1. / 3.)
 
+    @property
+    def surface_area(self):
+        v = self.vertices[self.faces.T]
+        ab = v[1] - v[0]
+        ac = v[2] - v[0]
+        normal = ab.cross(ac)
+        return normal.norm().sum() / 2
+
+    @property
+    def surface_equivalent_radius(self):
+        return np.sqrt(self.surface_area / (4 * np.pi))
+
     def rotated_vertices(self, sub_observer="00 00 00 +00 00 00", pole_position_angle=0):
         """Returns the vertices rotated as viewed by a given observer,
         with 'x' in the direction of the observer.

--- a/sora/body/shape/limb.py
+++ b/sora/body/shape/limb.py
@@ -13,10 +13,19 @@ class Limb:
 
     def __init__(self, *args, **kwargs):
         self._contour = geometry.LineString(*args, **kwargs)
+        self.shadow = geometry.Polygon(self._contour)
 
     @property
     def xy(self):
         return np.array(self._contour.xy)
+
+    @property
+    def shadow_area(self):
+        return self.shadow.area * u.km**2
+
+    @property
+    def shadow_equivalent_radius(self):
+        return np.sqrt(self.shadow_area/np.pi)
 
     def plot(self, center_f=0, center_g=0, scale=1, ax=None, **kwargs):
         """Plots the limb on the tangent plane


### PR DESCRIPTION
Included functions to compute the Equivalent Radius:

- The volumetric equivalent radius, where it computes the radius of the sphere that has the same volume of the 3D object.
  - `shape.volumetric_equivalent_radius`
- The surface area equivalent radius, where it computes the radius of the sphere that has the same surface area of the 3D object.
  - `shape.surface_equivalent_radius`
- The shadow equivalent radius, where it computes the radius of the circle that projects the same shadow area.
  - `limb.shadow_equivalent_radius`

The shadow equivalent radius must be obtained from the limb, while the others from the shape.