### PR TITLE
Bug fix: Correct fetching of stars via coordinates and SPK/BSP file downloads

### DIFF
--- a/sora/star/core.py
+++ b/sora/star/core.py
@@ -319,7 +319,7 @@ class Star(MetaStar):
         catalogue = catalogue[0]
         if len(catalogue) > 1:
             if self._verbose:
-                print('{} stars were found within 1 arcsec from given coordinate.'.format(len(catalogue)))
+                print('{} stars were found within {} arcsec from given coordinate.'.format(len(catalogue), int(radius.value)))
                 print('The list below is sorted by distance. Please select the correct star')
             catalogue = choice_star(catalogue, self.coord, ['RA_ICRS', 'DE_ICRS', 'Gmag'], source='gaia')
         cat_data = catalog.parse_catalogue(catalogue)

--- a/sora/star/core.py
+++ b/sora/star/core.py
@@ -299,15 +299,17 @@ class Star(MetaStar):
             except Exception as e:
                 raise ValueError(f"Search by code failed: {e}")
         elif hasattr(self, 'coord') and self.coord:
-            for radius in [1, 2, 4, 8, 16, 32] * u.arcsec:
+            search_radii = [1, 2, 4, 8, 16, 32] * u.arcsec
+
+            for radius in search_radii:
                 try:
                     catalogue = catalog.search_star(coord=self.coord, radius=radius)
                     if catalogue and len(catalogue) > 0:
                         break
+                    if radius < max(search_radii):
+                        print(f"Retrying search with a larger radius: {radius * 2}", end="\r")
                 except Exception as e:
                     warnings.warn(f"Search failed at radius {radius}: {e}")
-                if radius < 32 * u.arcsec:
-                    print(f"Retrying search with a larger radius: {radius*2}", end="\r")
                 
             if not catalogue or len(catalogue) == 0:
                 raise ValueError('No star was found. It does not exist or VizieR is out.')

--- a/sora/star/core.py
+++ b/sora/star/core.py
@@ -284,6 +284,7 @@ class Star(MetaStar):
 
     def __searchgaia(self, catalog):
         """Searches for the star position in the Gaia catalogue and save information.
+        If coord is given, iterates up to 32 arcsec radius to find the star.
 
         Parameters
         ----------
@@ -305,7 +306,9 @@ class Star(MetaStar):
                         break
                 except Exception as e:
                     warnings.warn(f"Search failed at radius {radius}: {e}")
-                print(f"Retrying search with a larger radius: {radius*2}", end="\r")
+                if radius < 32 * u.arcsec:
+                    print(f"Retrying search with a larger radius: {radius*2}", end="\r")
+                
             if not catalogue or len(catalogue) == 0:
                 raise ValueError('No star was found. It does not exist or VizieR is out.')
         else:


### PR DESCRIPTION
**Issue with Star Search and File Downloads**

The star search by coordinates would crash when no results were returned, due to missing error handling.

The BSP/SPK download function was outdated and didn’t work for many targets.


**Updates and Fixes**

The star search logic was updated to expand the search radius iteratively (up to 32 arcseconds) and now includes error handling to prevent crashes.

The BSP/SPK download function was fully rewritten with new logic.


**Current Behavior**

Star search handles empty results safely and expands the search area as needed.

The new BSP/SPK download supports all asteroids and Pluto, using Name, Number, Provisional Designation, and SPK IDs (with 'SPK' prefix).


